### PR TITLE
fix bug Send Amount

### DIFF
--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -372,14 +372,14 @@ export class AmountPage {
   }
 
   public pushDigit(digit: string): void {
-    // console.log('digit: ', digit);
+
     this.useSendMax = false;
     if (digit === 'delete') {
       return this.removeDigit();
     }
 
-    if (this.expression.length <= 0 && digit === '0') {
-      return;
+    if(this.expression.length  == 0 && digit === "." || this.expression === '0'){
+      this.expression = '0.'
     }
 
     if (


### PR DESCRIPTION
В кошельке при отправке если вводили точку для обозначения дроби, то пропадал 0 и отображалось " .201 " и т.п
Теперь отображается корректно " 0.201" 
Добавил возможность в первоначальном состояние нажать 0 и затем если  ввести любое число, то оно автоматически преобразуется в дробь