### PR TITLE
Update rate

### DIFF
--- a/src/providers/rate/rate.ts
+++ b/src/providers/rate/rate.ts
@@ -26,6 +26,8 @@ export class RateProvider {
     this.alternatives = {};
     for (const coin of this.currencyProvider.getAvailableCoins()) {
       this.rateServiceUrl[coin] = env.ratesAPI[coin];
+      let usdValue;
+      let ngnValue;
       const token = [
         'jamasy',
         'nuyasa',
@@ -37,25 +39,26 @@ export class RateProvider {
         'g.o.l.d.'
       ];
 
+      if (coin === 'ducx') {
+        usdValue = 0.6;
+        ngnValue = 0.6;
+      } else if (coin === 'duc') {
+        usdValue = 0.06;
+        ngnValue = 29.05;
+      } else if (coin === 'g.o.l.d.') {
+        usdValue = 0.01;
+        ngnValue = 0.01;
+      } else if (token.includes(coin)) {
+        usdValue = 1;
+        ngnValue = 1;
+      } else {
+        usdValue = this.rates[coin];
+        ngnValue = this.rates[coin];
+      }
+
       this.rates[coin] = {
-        USD:
-          coin === 'ducx'
-            ? 0.6
-            : coin === 'g.o.l.d.'
-            ? 0.01
-            : coin === 'duc'
-            ? 0.06
-            : token.includes(coin)
-            ? 1
-            : this.rates[coin],
-        NGN:
-          coin === 'ducx'
-            ? 0.6
-            : coin === 'duc'
-            ? 29.05
-            : token.includes(coin)
-            ? 1
-            : this.rates[coin] // test
+        USD: usdValue,
+        NGN: ngnValue
       };
       this.ratesAvailable[coin] = false;
       this.updateRates(coin);

--- a/src/providers/rate/rate.ts
+++ b/src/providers/rate/rate.ts
@@ -26,22 +26,26 @@ export class RateProvider {
     this.alternatives = {};
     for (const coin of this.currencyProvider.getAvailableCoins()) {
       this.rateServiceUrl[coin] = env.ratesAPI[coin];
+      const token = [
+        'jamasy',
+        'nuyasa',
+        'sunoba',
+        'dscmed',
+        'pog1',
+        'wde',
+        'mdxb',
+        'g.o.l.d.'
+      ];
+
       this.rates[coin] = {
         USD:
           coin === 'ducx'
             ? 0.6
+            : coin === 'g.o.l.d.'
+            ? 0.01
             : coin === 'duc'
             ? 0.06
-            : [
-                'jamasy',
-                'nuyasa',
-                'sunoba',
-                'dscmed',
-                'pog1',
-                'wde',
-                'mdxb',
-                'g.o.l.d.'
-              ].includes(coin)
+            : token.includes(coin)
             ? 1
             : this.rates[coin],
         NGN:
@@ -49,16 +53,7 @@ export class RateProvider {
             ? 0.6
             : coin === 'duc'
             ? 29.05
-            : [
-                'jamasy',
-                'nuyasa',
-                'sunoba',
-                'dscmed',
-                'pog1',
-                'wde',
-                'mdxb',
-                'g.o.l.d.'
-              ].includes(coin)
+            : token.includes(coin)
             ? 1
             : this.rates[coin] // test
       };


### PR DESCRIPTION
wrong alternate balance for gold
Теперь правильный рейт берет для расчета в USD
Я хз как из этой конструкции сделать что-то нормальное.Поэтому что ее используют вот так rate[USD][G.O.L.D.] для получения значения рейта. Ну т.е гений не мог написать для этого функцию. 

И крч тут либо писать нормально с нуля и искать везде где это используется. Либо так оставить.Я хз 