### PR TITLE
fix pathImg | SeedPage

### DIFF
--- a/src/pages/seed/seed.html
+++ b/src/pages/seed/seed.html
@@ -4,7 +4,7 @@
 
 
     <div class="fail-load" *ngIf="!nftData && loaded">
-        <img class="seedLogo" src="../../assets/img/seedLogo.png" alt="seedLogo">
+        <img class="seedLogo" src="assets/img/seedLogo.png" alt="seedLogo">
       <span>NO NFT</span>
     </div>
 
@@ -13,7 +13,7 @@
 
         <ion-label class="nft-item">
           <ion-icon>
-            <img class="nft-item-logo" src="../../assets/img/nftPreview.png" alt="nftPreview">
+            <img class="nft-item-logo" src="assets/img/nftPreview.png" alt="nftPreview">
           </ion-icon>
           <div class="nft-item-about">
             <h2 class="nft-item-about-number">#{{nft.number}}</h2>


### PR DESCRIPTION
На Андройде и на Айфоне не отображалось изображение нфт  + лого g.o.l.d.
Изменил пути, должно работать 